### PR TITLE
fix PHP 5.4 compatibility

### DIFF
--- a/src/Filter/FileSizeFilter.php
+++ b/src/Filter/FileSizeFilter.php
@@ -9,7 +9,8 @@ class FileSizeFilter extends AbstractFilter {
 
 	public function filter ($value) {
 		$i = floor( log($value) / log(1024) );
-		return number_format( $value / pow(1024, $i), 2) . ' ' . ['B', 'kB', 'MB', 'GB', 'TB'][$i];
+		$units = ['B', 'kB', 'MB', 'GB', 'TB'];
+		return number_format( $value / pow(1024, $i), 2) . ' ' . $units[$i];
 	}
 
 }


### PR DESCRIPTION
accessing items of array literals in PHP < 5.5 wasn't possible
