### PR TITLE
use v-if so the translation key detection doesnt break

### DIFF
--- a/fieldtypes/email/email.vue
+++ b/fieldtypes/email/email.vue
@@ -16,8 +16,14 @@
             <p v-if="field.data.help_text && field.data.help_show == 'block'"
                class="uk-form-help-block">{{{field.data.help_text}}}</p>
 
-            <p class="uk-form-help-block uk-text-danger" v-show="fieldInvalid(form)">{{ field.data.requiredError ||
-                'Please enter a value' | trans }}</p>
+            <p class="uk-form-help-block uk-text-danger" v-show="fieldInvalid(form)">
+                <span v-if="field.data.requiredError">
+                    {{ field.data.requiredError | trans }}
+                </span>
+                <span v-else>
+                    {{ 'Please enter a value' | trans }}
+                </span>
+            </p>
         </div>
     </div>
 

--- a/fieldtypes/text/text.vue
+++ b/fieldtypes/text/text.vue
@@ -16,8 +16,14 @@
             <p v-if="field.data.help_text && field.data.help_show == 'block'"
                class="uk-form-help-block">{{{field.data.help_text}}}</p>
 
-            <p class="uk-form-help-block uk-text-danger" v-show="fieldInvalid(form)">{{ field.data.requiredError ||
-                'Please enter a value' | trans }}</p>
+            <p class="uk-form-help-block uk-text-danger" v-show="fieldInvalid(form)">
+                <span v-if="field.data.requiredError">
+                    {{ field.data.requiredError | trans }}
+                </span>
+                <span v-else>
+                    {{ 'Please enter a value' | trans }}
+                </span>
+            </p>
         </div>
     </div>
 

--- a/fieldtypes/textbox/textbox.vue
+++ b/fieldtypes/textbox/textbox.vue
@@ -26,8 +26,14 @@
             <p v-if="field.data.help_text && field.data.help_show == 'block'"
                class="uk-form-help-block">{{{field.data.help_text}}}</p>
 
-            <p class="uk-form-help-block uk-text-danger" v-show="fieldInvalid(form)">{{ field.data.requiredError ||
-                'Please enter a value' | trans }}</p>
+            <p class="uk-form-help-block uk-text-danger" v-show="fieldInvalid(form)">
+                <span v-if="field.data.requiredError">
+                    {{ field.data.requiredError | trans }}
+                </span>
+                <span v-else>
+                    {{ 'Please enter a value' | trans }}
+                </span>
+            </p>
         </div>
     </div>
 


### PR DESCRIPTION
Hi Matthijs,

while translating we noticed that the key "Please enter a value" was missing. By using v-if instead of and inline `||` we could circumvent that restriction and the translate command will recognise it again.

Have a good one!
