### PR TITLE
Set config => required to -1 (dob)

### DIFF
--- a/fieldtypes/dob/index.php
+++ b/fieldtypes/dob/index.php
@@ -4,7 +4,7 @@ return [
 	'label' => __('Date of birth'),
 	'config' => [
 		'hasOptions' => 0,
-		'required' => 0,
+		'required' => -1,
 		'multiple' => 0,
 		'dateFormat' => 'MM-DD-YYYY',
 		'minAge' => 12,


### PR DESCRIPTION
Required is set to 0, which removes the user option to "checkbox" if the field should be required or not. This also prevents the form field from being published, as an error is thrown "Invalid value for required option"
