### PR TITLE
Set config => required to -1 (radio)

### DIFF
--- a/fieldtypes/radio/index.php
+++ b/fieldtypes/radio/index.php
@@ -4,7 +4,7 @@ return [
 	'label' => __('Radio bullets'),
 	'config' => [
 		'hasOptions' => 1,
-		'required' => 0,
+		'required' => -1,
 		'multiple' => 1,
 	]
 ];


### PR DESCRIPTION
Required is set to 0, which removes the user option to "checkbox" if the field should be required or not. This also prevents the form field from being published, as an error is thrown "Invalid value for required option"
