### PR TITLE
Set config => required to -1 (upload)

### DIFF
--- a/fieldtypes/upload/index.php
+++ b/fieldtypes/upload/index.php
@@ -7,7 +7,7 @@ return [
 	'autoload' => ['Bixie\\Framework\\FieldType\\Upload\\' => 'src'],
 	'config' => [
 		'hasOptions' => 0,
-		'required' => 0,
+		'required' => -1,
 		'multiple' => 1,
 		'path' => 'uploads',
 		'allowed' => ['png', 'jpg', 'jpeg', 'gif', 'svg'],


### PR DESCRIPTION
Required is set to 0, which removes the user option to "checkbox" if the field should be required or not. This also prevents the form field from being published, as an error is thrown "Invalid value for required option"
