### PR TITLE
Set config => required to -1 (htmlcode)

### DIFF
--- a/fieldtypes/htmlcode/index.php
+++ b/fieldtypes/htmlcode/index.php
@@ -6,7 +6,7 @@ return [
 	'label' => __('Html code'),
 	'config' => [
 		'hasOptions' => 0,
-		'required' => 0,
+		'required' => -1,
 		'multiple' => 0,
 		'markdown' => ''
 	],


### PR DESCRIPTION
Required is set to 0, which removes the user option to "checkbox" if the field should be required or not. This also prevents the form field from being published, as an error is thrown "Invalid value for required option"
