### PR TITLE
Set config => required to -1

### DIFF
--- a/fieldtypes/checkbox/index.php
+++ b/fieldtypes/checkbox/index.php
@@ -4,7 +4,7 @@ return [
 	'label' => __('Checkboxes'),
 	'config' => [
 		'hasOptions' => 1,
-		'required' => 0,
+		'required' => -1,
 		'multiple' => 1,
 	]
 ];

--- a/fieldtypes/dob/index.php
+++ b/fieldtypes/dob/index.php
@@ -4,7 +4,7 @@ return [
 	'label' => __('Date of birth'),
 	'config' => [
 		'hasOptions' => 0,
-		'required' => 0,
+		'required' => -1,
 		'multiple' => 0,
 		'dateFormat' => 'MM-DD-YYYY',
 		'minAge' => 12,

--- a/fieldtypes/htmlcode/index.php
+++ b/fieldtypes/htmlcode/index.php
@@ -6,7 +6,7 @@ return [
 	'label' => __('Html code'),
 	'config' => [
 		'hasOptions' => 0,
-		'required' => 0,
+		'required' => -1,
 		'multiple' => 0,
 		'markdown' => ''
 	],

--- a/fieldtypes/radio/index.php
+++ b/fieldtypes/radio/index.php
@@ -4,7 +4,7 @@ return [
 	'label' => __('Radio bullets'),
 	'config' => [
 		'hasOptions' => 1,
-		'required' => 0,
+		'required' => -1,
 		'multiple' => 1,
 	]
 ];

--- a/fieldtypes/upload/index.php
+++ b/fieldtypes/upload/index.php
@@ -7,7 +7,7 @@ return [
 	'autoload' => ['Bixie\\Framework\\FieldType\\Upload\\' => 'src'],
 	'config' => [
 		'hasOptions' => 0,
-		'required' => 0,
+		'required' => -1,
 		'multiple' => 1,
 		'path' => 'uploads',
 		'allowed' => ['png', 'jpg', 'jpeg', 'gif', 'svg'],


### PR DESCRIPTION
Required is set to 0, which removes the user option to "checkbox" if the field should be required or not. This also prevents the form field from being published, as an error is thrown "Invalid value for required option"

Applies to:
checkboxes
htmlcode
upload
radio
dob
