### PR TITLE
Add Label to HTMLCODE Field in UserProfile Tab

### DIFF
--- a/fieldtypes/htmlcode/htmlcode.vue
+++ b/fieldtypes/htmlcode/htmlcode.vue
@@ -2,7 +2,15 @@
 
     <div :class="classes(['uk-form-row', (isAdmin ? 'uk-hidden' : '')], field.data.classSfx)">
 
-        {{{ fieldValue.formatted[0] }}}
+        <span class="uk-form-label" v-show="!field.data.hide_label">{{ fieldLabel | trans }}
+            <a v-if="field.data.help_text && field.data.help_show == 'tooltip_icon'"
+               class="uk-icon-info uk-icon-hover uk-margin-small-top uk-float-right"
+               :title="field.data.help_text" data-uk-tooltip="{delay: 100}"></a>
+        </span>
+
+        <div class="uk-form-controls">
+            {{{ fieldValue.formatted[0] }}}
+        </div>
 
     </div>
 


### PR DESCRIPTION
Added the code for a label, which is missing from this form field. When looking at the "userprofile" tab of a user in the Admin > Users page, only the value was displayed.
